### PR TITLE
fix(middleware): fix plugins pipeline with final middleware

### DIFF
--- a/src/plugins/middleware.ts
+++ b/src/plugins/middleware.ts
@@ -22,9 +22,12 @@ const middlewarePlugin: Plugin = (app) => {
   const middlewares: Middleware[] = [];
   const errorMiddlewares: MiddlewareError[] = [];
 
-  const finalErrorHandler: MiddlewareError = (error, req, res, next) => {
-    res.end(JSON.stringify(error));
+  const finalSuccessHandler: (next: () => void) => Middleware = (next) => () => {
     next();
+  };
+
+  const finalErrorHandler: MiddlewareError = (error, _req, res) => {
+    res.end(JSON.stringify({ error }));
   };
 
   Object.defineProperty(app, 'use', {
@@ -39,9 +42,9 @@ const middlewarePlugin: Plugin = (app) => {
 
   return {
     name: 'middleware',
-    pre: (req, res) => {
+    pre: (req, res, next) => {
       try {
-        nextMiddleware(middlewares, req, res);
+        nextMiddleware([...middlewares, finalSuccessHandler(next)], req, res);
       } catch (error) {
         nextMiddleware([...errorMiddlewares, finalErrorHandler], req, res, error);
       }

--- a/test/plugins/middleware.spec.ts
+++ b/test/plugins/middleware.spec.ts
@@ -120,4 +120,26 @@ describe('Guarapi - plugins/middleware', () => {
     expect(middlewareThree).not.toBeCalledTimes(1);
     expect(middlewareFour).toBeCalledTimes(1);
   });
+
+  it('should plugins pipeline not break if it has no final middleware', async () => {
+    const { app, server } = buildApp();
+    const pluginOneHandler = jest.fn();
+    const pluginOne = () => ({
+      name: 'plugin one',
+      pre: (req, res) => {
+        pluginOneHandler();
+        res.end('ok');
+      },
+    });
+
+    app.plugin(pluginOne);
+
+    app.use((req, res, next) => {
+      next();
+    });
+
+    await request(server).get('/');
+
+    expect(pluginOneHandler).toBeCalledTimes(1);
+  });
 });


### PR DESCRIPTION
The middleware plugin currently breaks the plugin pipeline. The problem is that it doesn't call the `next` plugin function.
