### PR TITLE
fix(middleware): error handler types can't be inferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ import guarapi, {
   middlewarePlugin,
   loggerPlugin,
   Router,
+  MiddlewareError,
 } from 'guarapi';
 
 const app = guarapi();
@@ -28,8 +29,8 @@ router.get('/', (req, res) => {
 
 app.use(router);
 
-app.use((error, _req, res, _next) => {
-  res.statusCode = error ? 500 : 404;
+app.use<MiddlewareError>((error, _req, res, _next) => {
+  res.statusCode = (error as Error)?.message === 'Not Found' ? 404 : 500;
   res.end(`Error: ${(error as Error)?.message || 'Internal Server Error'}`);
 });
 

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -1,4 +1,4 @@
-import { GuarapiLogger, Plugin } from '../types';
+import { GuarapiLogger, MiddlewareError, Plugin } from '../types';
 
 declare module '../types' {
   interface Guarapi {
@@ -20,7 +20,7 @@ const loggerPlugin: Plugin = (app) => {
     value: logger,
   });
 
-  app.use((error, req, res, next) => {
+  app.use<MiddlewareError>((error, req, _res, next) => {
     logger('error', req);
     next(error);
   });

--- a/src/plugins/middleware.ts
+++ b/src/plugins/middleware.ts
@@ -3,8 +3,8 @@ import nextMiddleware from '../lib/next-pipeline';
 
 declare module '../types' {
   interface Guarapi {
-    use(middleware: Middleware | MiddlewareError): void;
-    use(path: string, middleware: Middleware | MiddlewareError): void;
+    use<T = Middleware>(middleware: T): void;
+    use<T = Middleware>(path: string, middleware: T): void;
   }
 }
 
@@ -21,8 +21,6 @@ const middlewarePlugin: Plugin = (app) => {
   const middlewares: { path: string; handler: Middleware }[] = [];
   const errorMiddlewares: MiddlewareError[] = [];
 
-  function use(middleware: Middleware | MiddlewareError): void;
-  function use(path: string, middleware: Middleware | MiddlewareError): void;
   function use<P, M>(path: P, middleware?: M): void {
     const middlewarePath = (typeof path === 'string' ? path : '/').replace(/\/?$/, '');
     const middlewareHandler = (typeof path && middleware ? middleware : path) as

--- a/test/lib/router.spec.ts
+++ b/test/lib/router.spec.ts
@@ -1,5 +1,11 @@
 import { request } from '../utils';
-import guarapi, { GuarapiConfig, Router, createServer, middlewarePlugin } from '../../src';
+import guarapi, {
+  GuarapiConfig,
+  MiddlewareError,
+  Router,
+  createServer,
+  middlewarePlugin,
+} from '../../src';
 
 describe('Guarapi - lib/router', () => {
   const buildApp = (options?: GuarapiConfig) => {
@@ -481,12 +487,12 @@ describe('Guarapi - lib/router', () => {
     http1.app.use(router);
     http2.app.use(router);
 
-    http1.app.use((error, _req, res, _next) => {
+    http1.app.use<MiddlewareError>((error, _req, res, _next) => {
       catchError((error as Error).message);
       res.end();
     });
 
-    http2.app.use((error, _req, res, _next) => {
+    http2.app.use<MiddlewareError>((error, _req, res, _next) => {
       catchError((error as Error).message);
       res.end();
     });

--- a/test/plugins/body-parser.spec.ts
+++ b/test/plugins/body-parser.spec.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import request from 'supertest';
-import guarapi, { bodyParserPlugin, middlewarePlugin } from '../../src';
+import guarapi, { MiddlewareError, bodyParserPlugin, middlewarePlugin } from '../../src';
 
 describe('Guarapi - plugins/body-parser', () => {
   const buildApp = () => {
@@ -69,7 +69,7 @@ describe('Guarapi - plugins/body-parser', () => {
       res.end();
     });
 
-    app.use((error, req, res, _next) => {
+    app.use<MiddlewareError>((error, req, res, _next) => {
       errorHandler();
       res.end();
     });

--- a/test/plugins/middleware.spec.ts
+++ b/test/plugins/middleware.spec.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import request from 'supertest';
-import guarapi, { middlewarePlugin } from '../../src';
+import guarapi, { MiddlewareError, middlewarePlugin } from '../../src';
 
 describe('Guarapi - plugins/middleware', () => {
   const buildApp = (plugins = [middlewarePlugin]) => {
@@ -99,7 +99,7 @@ describe('Guarapi - plugins/middleware', () => {
       res.end('ok');
     });
 
-    app.use((error, req, res, _next) => {
+    app.use<MiddlewareError>((error, req, res, _next) => {
       middlewareFour(error);
       res.end('ERROR');
     });
@@ -142,7 +142,7 @@ describe('Guarapi - plugins/middleware', () => {
       res.end('ok');
     });
 
-    app.use((error, req, res, _next) => {
+    app.use<MiddlewareError>((error, req, res, _next) => {
       middlewareFour();
       res.end('ERROR');
     });


### PR DESCRIPTION
update README.md example
add MiddlewareError in app.use() with error handler